### PR TITLE
Doc fig bugfix

### DIFF
--- a/docs/examples/gen_velocities.rst
+++ b/docs/examples/gen_velocities.rst
@@ -38,7 +38,7 @@ Imports.
 Set up support for plotting :py:class:`~astropy.units.quantity.Quantity` and
 :py:class:`~astropy.time.Time` objects.
 
-  .. plot::
+.. plot::
     :include-source:
     :context:
 
@@ -203,8 +203,8 @@ Calculate some derived quantities:
 
     delta_omega_p = omega_s - omega_p
 
-Define grid of observing times :math:`t` for which you want to calculate
-velocities using a a :py:class:`~astropy.time.Time` object.
+Define a grid of observing times :math:`t` for which you want to calculate
+velocities using a :py:class:`~astropy.time.Time` object.
 
 .. plot::
     :include-source:

--- a/docs/examples/simple_examples.rst
+++ b/docs/examples/simple_examples.rst
@@ -9,7 +9,7 @@ observation will look rather plain. In the secondary spectrum, there will be a
 single non-zero point at the origin.
 
 .. plot::
-    :context:
+    :context: close-figs
 
     import numpy as np
     from astropy import units as u


### PR DESCRIPTION
@mhvk - I noticed that somehow (!?) the last plot from [gen_velocities](https://screens.readthedocs.io/en/latest/examples/gen_velocities.html) started showing up at the beginning of [simple_examples](https://screens.readthedocs.io/en/latest/examples/simple_examples.html). The second commit in this PR makes it go away; the first commit fixes a few typos I noticed in gen_velocities.rst