### PR TITLE
Add little explanations for each ToC entry in the index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,10 @@
 .. include:: ../README.rst
 
+.. Sphinx requires that all source document files it finds are part of some
+.. table of contents using the `toctree` directive. Without this hidden ToC,
+.. sphinx gives a warning for all `.rst` files in the documentation:
+.. `WARNING: document isn't included in any toctree`
+
 .. toctree::
     :hidden:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,19 +16,49 @@
     tutorials/fit_velocities
     tutorials/infer_phys_pars
 
+
 Background
 ==========
+
+* :doc:`background/simple_examples`:
+  the dynamic and secondary spectra, and wavefield for elementary situations
+* :doc:`background/multiple_screens`:
+  derivation of the scattering angles and velocities
+* :doc:`background/velocities`:
+  derivation for a pulsar on a circular orbit and a single linear screen
+* :doc:`background/glossary`:
+  list of terms used in modelling scintillation velocities
 
 
 Tutorials
 =========
 
+
 Generating and processing scintillometry data
 ---------------------------------------------
+
+* :doc:`tutorials/single_screen`:
+  how to generate the dynamic and secondary spectrum
+* :doc:`tutorials/screen1d`:
+  generate synthetic data and visualize the system (for a single screen)
+* :doc:`tutorials/two_screens`:
+  how to use Screen1D for radiation scattered by multiple screens
 
 
 Modelling scintillation velocities
 ----------------------------------
+
+This is a sequence of interconnected tutorials dealing with time series of
+scintillation velocities (or curvature). See also the background document on
+:doc:`scintillation velocities <background/velocities>` for a derivation of the
+equation appearing in these tutorials.
+
+* :doc:`tutorials/gen_velocities`:
+  make synthetic time series of scintillation velocities or curvature
+* :doc:`tutorials/fit_velocities`:
+  fit a phenomenological model to a time series of scintillation velocities
+* :doc:`tutorials/infer_phys_pars`:
+  retrieve the physical parameters of the system from the fit
 
 
 Reference/API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,24 @@
 .. include:: ../README.rst
 
+.. toctree::
+    :hidden:
+
+    background/simple_examples
+    background/multiple_screens
+    background/velocities
+    background/glossary
+
+    tutorials/single_screen
+    tutorials/screen1d
+    tutorials/two_screens
+
+    tutorials/gen_velocities
+    tutorials/fit_velocities
+    tutorials/infer_phys_pars
+
 Background
 ==========
 
-.. toctree::
-   :maxdepth: 1
-
-   background/simple_examples
-   background/multiple_screens
-   background/velocities
-   background/glossary
 
 Tutorials
 =========
@@ -17,22 +26,10 @@ Tutorials
 Generating and processing scintillometry data
 ---------------------------------------------
 
-.. toctree::
-   :maxdepth: 1
-
-   tutorials/single_screen
-   tutorials/screen1d
-   tutorials/two_screens
 
 Modelling scintillation velocities
 ----------------------------------
 
-.. toctree::
-   :maxdepth: 1
-
-   tutorials/gen_velocities
-   tutorials/fit_velocities
-   tutorials/infer_phys_pars
 
 Reference/API
 =============


### PR DESCRIPTION
@mhvk - This is ready for review. I had a look at a few examples of documentation index pages ([Python 3 documentation](https://docs.python.org/3/), [Python Developer's Guide](https://devguide.python.org/), [NumPy documentation](https://numpy.org/doc/stable/)) and decided on implementing this with a hidden `toctree` to let Sphinx know about all the documents, and write the index page manually.
