### PR TITLE
Update build/run/docs requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ github_project = mhvk/screens
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    astropy
+    astropy>=4.3
     scipy
     baseband-tasks
     matplotlib
@@ -27,9 +27,9 @@ install_requires =
 test =
     pytest-astropy
 docs =
-    astropy!=4.3
+    astropy>=5.0
     sphinx<4.0
-    sphinx-astropy
+    sphinx-astropy>=1.6
     jupyter-sphinx
     uncertainties
     corner

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-oldestdeps,-alldeps,-devdeps}{,-cov}
+    py{38,39,310}-test{,-oldestdeps,-alldeps,-devdeps}{,-cov}
     build_docs
     codestyle
 requires =
@@ -35,8 +35,7 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
 
-    oldestdeps: astropy==3.1.*
-    oldestdeps: numpy==1.16.*
+    oldestdeps: astropy==3.4.*
 
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
fixes #64 (hopefully).

And high time to update it anyway, especially as geetam got in trouble with a CITA setup using python 3.6 and a very old numpy...