### PR TITLE
Use jupyter-input directive for cells that should not be run

### DIFF
--- a/docs/tutorials/fit_velocities.rst
+++ b/docs/tutorials/fit_velocities.rst
@@ -863,11 +863,8 @@ Finally, we use NumPy's :py:func:`~numpy.savez` to save the solution and the
 accompanying covariance matrix found by :py:func:`~scipy.optimize.curve_fit`,
 to do an error analysis in a :doc:`later tutorial <error_analysis>`.
 
-.. jupyter-execute::
+.. jupyter-input::
 
-    # np.savez('data/fit-results-J0437.npz',
-    #          popt=popt,
-    #          pcov=pcov)
-
-.. TODO: When jupyter-sphinx v0.4 is available, this last directive can be
-.. changed to jupyter-input and the Python code can be uncommented
+    np.savez('data/fit-results-J0437.npz',
+             popt=popt,
+             pcov=pcov)

--- a/docs/tutorials/gen_velocities.rst
+++ b/docs/tutorials/gen_velocities.rst
@@ -487,12 +487,9 @@ Now we add some noise to the scaled effective velocities.
 Finally, we use NumPy's :py:func:`~numpy.savez` to save the data as a set of
 (unitless) NumPy arrays.
 
-.. jupyter-execute::
+.. jupyter-input::
 
-    # np.savez('data/fake-data-J0437.npz',
-    #          t_mjd=t.mjd,
-    #          dveff_obs=dveff_obs.value,
-    #          dveff_err=dveff_err.value)
-
-.. TODO: When jupyter-sphinx v0.4 is available, this last directive can be
-.. changed to jupyter-input and the Python code can be uncommented
+    np.savez('data/fake-data-J0437.npz',
+             t_mjd=t.mjd,
+             dveff_obs=dveff_obs.value,
+             dveff_err=dveff_err.value)


### PR DESCRIPTION
We had some code blocks in the docs containing only commented-out code. The reason for having these was to show the code in the docs, but we didn't want these blocks to run because they produce data files. I don't remember why exactly producing those data files was a problem.

When I worked on this 2 years ago, I read that a new version of `jupyter-sphinx` would feature a solution: a directive to just show the code as an input cell, without executing it. This commit was just waiting for that new version, which is out by now (and has been for quite some time, I imagine).