### PR TITLE
ENH: ensure remap_time can deal with complex data

### DIFF
--- a/screens/remap.py
+++ b/screens/remap.py
@@ -61,7 +61,7 @@ def remap_time(ds, t_map, new_t):
     # Ensure the lower bound is always below the upper bound.
     bounds_l, bounds_u = np.minimum(bounds_l, bounds_u), np.maximum(bounds_l, bounds_u)
     # Create output and weight arrays.
-    out = np.zeros((len(new_t),)+ds.shape[1:])
+    out = np.zeros_like(ds, shape=(len(new_t),)+ds.shape[1:])
     weight = np.zeros((len(new_t),)+ds.shape[1:])
     # As well as a fake frequency pixel axis (needed for the case that t_map
     # depends on the frequency axis as well).

--- a/screens/tests/test_remap.py
+++ b/screens/tests/test_remap.py
@@ -66,3 +66,10 @@ class TestRemapTime:
         expected = self.scint(self.new_pos, self.scale[0])
         expected = np.broadcast_to(expected[:, np.newaxis], out.shape)
         assert_allclose(out, expected, atol=0.015)
+
+
+class TestRemapTimeComplex(TestRemapTime):
+    @staticmethod
+    def scint(pos, scale=3.):
+        """Super simple interference pattern."""
+        return np.exp(1j*(pos*scale*u.cy).to_value(u.rad))


### PR DESCRIPTION
Really an oversight in #78 - might as well ensure the output array has the same type, so complex data can be handled.